### PR TITLE
Remove sold out calculations to reduce database queries

### DIFF
--- a/templates/espresso-events-table-template-toggle.template.php
+++ b/templates/espresso-events-table-template-toggle.template.php
@@ -94,7 +94,7 @@ if ( have_posts() ) :
 		//Create the register now button
 		$live_button 		= '<a id="a_register_link-'.$post->ID.'" class="a_register_link" href="'.$registration_url.'">'.$button_text.'</a>';
 
-		if ( $event->is_sold_out() || $event->is_sold_out(TRUE ) ) {
+		if ( $event->is_sold_out() ) {
 			$live_button	= '<a id="a_register_link-'.$post->ID.'" class="a_register_link_sold_out a_register_link" href="'.$registration_url.'">'.$sold_out_button_text.'</a>';
 		}
 

--- a/templates/espresso-events-table-template.template.php
+++ b/templates/espresso-events-table-template.template.php
@@ -94,7 +94,7 @@ if ( have_posts() ) :
 		//Create the register now button
 		$live_button 		= '<a id="a_register_link-'.$post->ID.'" class="a_register_link" href="'.$registration_url.'">'.$button_text.'</a>';
 
-		if ( $event->is_sold_out() || $event->is_sold_out(TRUE ) ) {
+		if ( $event->is_sold_out() ) {
 			$live_button	= '<a id="a_register_link-'.$post->ID.'" class="a_register_link_sold_out a_register_link" href="'.$registration_url.'">'.$sold_out_button_text.'</a>';
 		}
 


### PR DESCRIPTION

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
Larger than usual number of database queries on pages that have the events table template shortcode. 
## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->
Viewed the page with the events table template shortcode and viewed the debug bar's saved queries for the request. The sold out events show "Sold Out" in the link text. 
## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
